### PR TITLE
Logger being accessed before initialization

### DIFF
--- a/src/Repositories/Implementation/Doctrine/BaseDoctrineRepository.php
+++ b/src/Repositories/Implementation/Doctrine/BaseDoctrineRepository.php
@@ -20,11 +20,11 @@ class BaseDoctrineRepository implements RepositoryInterface
     private bool $isTransactionActive = false;
     protected static ?LoggerInterface $logger;
 
-    public function __construct(EntityManager $em, ObjectRepository $or)
+    public function __construct(EntityManager $em, ObjectRepository $or, ?LoggerInterface $logger = null)
     {
         $this->entityManager = $em;
         $this->genericRepository = $or;
-
+        self::$logger = $logger;
     }
 
     public function findAll(): array


### PR DESCRIPTION
I could not get the app to run without changing the logger initialization. 
```
wsl-anderson@DESKTOP-CDSHO8I:~/dev/BudgetKeeper/Backend$ php -S localhost:8080 -t public
[Sun Oct  8 22:00:33 2023] PHP 8.2.11 Development Server (http://localhost:8080) started
[Sun Oct  8 22:00:35 2023] 127.0.0.1:58582 Accepted
[Sun Oct  8 22:00:35 2023] PHP Fatal error:  Uncaught Error: Typed static property App\Repositories\Implementation\Doctrine\BaseDoctrineRepository::$logger must not 
be accessed before initialization in /home/wsl-anderson/dev/BudgetKeeper/Backend/src/Repositories/Implementation/Doctrine/BaseDoctrineRepository.php:170
Stack trace:
#0 /home/wsl-anderson/dev/BudgetKeeper/Backend/src/Repositories/Implementation/Doctrine/BaseDoctrineRepository.php(107): App\Repositories\Implementation\Doctrine\Bas
eDoctrineRepository->getLogger()
#1 /home/wsl-anderson/dev/BudgetKeeper/Backend/src/Middlewares/Site/LogSiteVisitMiddleware.php(37): App\Repositories\Implementation\Doctrine\BaseDoctrineRepository->
saveSingle()
#2 /home/wsl-anderson/dev/BudgetKeeper/Backend/src/Middlewares/Site/LogSiteVisitMiddleware.php(27): App\Middlewares\Site\LogSiteVisitMiddleware->addSiteVisit()      
#3 /home/wsl-anderson/dev/BudgetKeeper/Backend/vendor/slim/slim/Slim/MiddlewareDispatcher.php(168): App\Middlewares\Site\LogSiteVisitMiddleware->__invoke()
#4 /home/wsl-anderson/dev/BudgetKeeper/Backend/vendor/slim/slim/Slim/MiddlewareDispatcher.php(65): Psr\Http\Server\RequestHandlerInterface@anonymous->handle()       
#5 /home/wsl-anderson/dev/BudgetKeeper/Backend/vendor/slim/slim/Slim/App.php(199): Slim\MiddlewareDispatcher->handle()
#6 /home/wsl-anderson/dev/BudgetKeeper/Backend/vendor/slim/slim/Slim/App.php(183): Slim\App->handle()
#7 /home/wsl-anderson/dev/BudgetKeeper/Backend/public/index.php(12): Slim\App->run()
#8 {main}
  thrown in /home/wsl-anderson/dev/BudgetKeeper/Backend/src/Repositories/Implementation/Doctrine/BaseDoctrineRepository.php on line 170
[Sun Oct  8 22:00:35 2023] 127.0.0.1:58582 [500]: GET / - Uncaught Error: Typed static property App\Repositories\Implementation\Doctrine\BaseDoctrineRepository::$log
ger must not be accessed before initialization in /home/wsl-anderson/dev/BudgetKeeper/Backend/src/Repositories/Implementation/Doctrine/BaseDoctrineRepository.php:170
Stack trace:
#0 /home/wsl-anderson/dev/BudgetKeeper/Backend/src/Repositories/Implementation/Doctrine/BaseDoctrineRepository.php(107): App\Repositories\Implementation\Doctrine\Bas
eDoctrineRepository->getLogger()
```

Not sure if this PR ensures correct singleton lifecycle of the logger, but this does at least start the app.